### PR TITLE
Fix runtime error by using HttpClientModule

### DIFF
--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -1,11 +1,15 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { HttpClientModule } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 
 import { AppComponent } from './app.component';
 import { WikiCardComponent } from './wiki-card/wiki-card.component';
 
-@NgModule({ declarations: [AppComponent, WikiCardComponent],
-    bootstrap: [AppComponent], imports: [BrowserModule, FormsModule], providers: [provideHttpClient(withInterceptorsFromDi())] })
+@NgModule({
+  declarations: [AppComponent, WikiCardComponent],
+  imports: [BrowserModule, FormsModule, HttpClientModule],
+  bootstrap: [AppComponent],
+  providers: []
+})
 export class AppModule {}


### PR DESCRIPTION
## Summary
- import `HttpClientModule` instead of environment providers

The app was injecting `provideHttpClient` inside `AppModule`, which Angular
reports as `NG0908`. Using `HttpClientModule` resolves the issue.

## Testing
- `npm start` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68725f0ec4008328b984127b290172c5