### PR TITLE
Add likes overlay and share support in Angular app

### DIFF
--- a/angular-app/src/app/app.component.css
+++ b/angular-app/src/app/app.component.css
@@ -48,3 +48,72 @@ body {
   justify-content: center;
   color: #fff;
 }
+
+.likes-btn {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 10;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.likes-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.likes-panel {
+  background: #111;
+  color: #fff;
+  padding: 1rem;
+  max-height: 80vh;
+  overflow-y: auto;
+  width: 90%;
+  max-width: 600px;
+  position: relative;
+}
+
+.likes-panel h2 {
+  margin-top: 0;
+}
+
+.close-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.liked-item {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.liked-item img {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+}
+
+.liked-item .info {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/angular-app/src/app/app.component.html
+++ b/angular-app/src/app/app.component.html
@@ -9,3 +9,22 @@
   <div #observer class="sentinel"></div>
   <div *ngIf="loading" class="loading">Loading...</div>
 </div>
+
+<button class="likes-btn" (click)="toggleLikesMenu()">
+  Likes ({{ liked.articles.length }})
+</button>
+
+<div class="likes-overlay" *ngIf="showLikes" (click)="toggleLikesMenu()">
+  <div class="likes-panel" (click)="$event.stopPropagation()">
+    <button class="close-btn" (click)="toggleLikesMenu()">✕</button>
+    <h2>Liked Articles</h2>
+    <div *ngIf="liked.articles.length === 0">No liked articles yet.</div>
+    <div *ngFor="let art of liked.articles" class="liked-item">
+      <img *ngIf="art.thumbnail" [src]="art.thumbnail.source" [alt]="art.title" />
+      <div class="info">
+        <a [href]="art.url" target="_blank" rel="noopener noreferrer">{{ art.displaytitle }}</a>
+        <button (click)="toggleLike(art)" aria-label="Remove">✕</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/angular-app/src/app/app.component.ts
+++ b/angular-app/src/app/app.component.ts
@@ -12,6 +12,7 @@ import type { WikiArticle } from './wiki-card/wiki-card.component';
 export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   articles: WikiArticle[] = [];
   loading = false;
+  showLikes = false;
   private observer?: IntersectionObserver;
   @ViewChild('observer', { static: false }) observerElem!: ElementRef<HTMLDivElement>;
 
@@ -51,5 +52,9 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
   toggleLike(article: WikiArticle) {
     this.liked.toggle(article);
+  }
+
+  toggleLikesMenu() {
+    this.showLikes = !this.showLikes;
   }
 }

--- a/angular-app/src/app/wiki-card/wiki-card.component.css
+++ b/angular-app/src/app/wiki-card/wiki-card.component.css
@@ -52,3 +52,35 @@ p {
 .actions {
   margin-top: 1rem;
 }
+
+.top-actions {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.top-actions button {
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.top-actions button.liked {
+  background: #e0245e;
+}
+
+.read-more {
+  color: #fff;
+  text-decoration: underline;
+  display: inline-block;
+  margin-top: 0.5rem;
+}

--- a/angular-app/src/app/wiki-card/wiki-card.component.html
+++ b/angular-app/src/app/wiki-card/wiki-card.component.html
@@ -6,11 +6,14 @@
   />
   <div class="gradient"></div>
   <div class="content">
+    <div class="top-actions">
+      <button (click)="toggleLike()" [class.liked]="liked" aria-label="Like">
+        ❤️
+      </button>
+      <button (click)="shareArticle()" aria-label="Share">🔗</button>
+    </div>
     <h2>{{ article.displaytitle }}</h2>
     <p>{{ article.extract }}</p>
-    <div class="actions">
-      <button (click)="toggleLike()">{{ liked ? 'Unlike' : 'Like' }}</button>
-      <button (click)="shareArticle()">Share</button>
-    </div>
+    <a class="read-more" [href]="article.url" target="_blank" rel="noopener noreferrer">Читать дальше...</a>
   </div>
 </div>

--- a/angular-app/src/app/wiki-card/wiki-card.component.ts
+++ b/angular-app/src/app/wiki-card/wiki-card.component.ts
@@ -19,6 +19,7 @@ export class WikiCardComponent {
   @Input() article!: WikiArticle;
   @Input() liked = false;
   @Output() like = new EventEmitter<WikiArticle>();
+  // Share event emitter is kept for potential parent handling
   @Output() share = new EventEmitter<WikiArticle>();
 
   toggleLike() {
@@ -26,6 +27,14 @@ export class WikiCardComponent {
   }
 
   shareArticle() {
+    const { displaytitle, url, extract } = this.article;
+    const nav: any = navigator;
+    if (nav.share) {
+      nav.share({ title: displaytitle, text: extract, url }).catch(() => {});
+    } else if (nav.clipboard) {
+      nav.clipboard.writeText(url);
+      alert('Link copied to clipboard!');
+    }
     this.share.emit(this.article);
   }
 }


### PR DESCRIPTION
## Summary
- implement share handler on wiki cards
- move like/share buttons to top right and show as icons
- add "Read more" links
- add likes overlay to list saved articles

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm run lint` in frontend *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68727f0a9a508328af033f5ce073747f